### PR TITLE
Fix NetCDF URL buy using Github relase.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/netcdf
-        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}
+        key: netcdf-c-${{ matrix.netcdf_version }}-${{ runner.os }}1
 
     - name: build-hdf5
       if: steps.cache-netcdf.outputs.cache-hit != 'true'
@@ -59,8 +59,8 @@ jobs:
         export CC=mpicc
         export CPPFLAGS=-I${HOME}/netcdf/include
         export LDFLAGS=-L${HOME}/netcdf/lib
-        wget https://www.unidata.ucar.edu/downloads/netcdf/ftp/netcdf-c-${{ matrix.netcdf_version }}.tar.gz &> /dev/null
-        tar -xzf netcdf-c-${{ matrix.netcdf_version }}.tar.gz
+        wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v${{ matrix.netcdf_version }}.tar.gz
+        tar -xzf v${{ matrix.netcdf_version }}.tar.gz
         cd netcdf-c-${{ matrix.netcdf_version }}
         ./configure --prefix=${HOME}/netcdf --disable-dap --disable-utilities
         make -j2


### PR DESCRIPTION
The NCAR URL only contains the latest release of NetCDF.