### PR TITLE
updated readme and fixed the gcovr problem in the CI system

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -22,8 +22,6 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
-
     - name: install-dependencies
       run: |
         sudo apt-get update
@@ -76,10 +74,17 @@ jobs:
         make -j2
         make install   
        
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: ncio
+
     - name: build
       run: |
         export FC=mpifort
         export CC=mpicc
+        set -x
+        cd ncio
         mkdir build && cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
@@ -88,7 +93,7 @@ jobs:
       run: |
         pwd
         ls -l 
-        cd $GITHUB_WORKSPACE/build
+        cd $GITHUB_WORKSPACE/ncio/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -82,7 +82,7 @@ jobs:
         export FC=mpifort
         export CC=mpicc
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
     
     - name: test

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -90,7 +90,7 @@ jobs:
         ls -l 
         cd $GITHUB_WORKSPACE/build
         ctest --verbose --output-on-failure --rerun-failed
-        gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null
+        gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
 
     - uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -5,13 +5,7 @@
 #
 # Ed Hartnett 1/12/23
 name: developer
-on:
-  push:
-    branches:
-    - develop
-  pull_request:
-    branches:
-    - develop
+on: [push, pull_request]
 
 jobs:
   developer:
@@ -19,6 +13,9 @@ jobs:
     env:
       FC: gfortran
       CC: gcc
+
+    strategy:
+      fail-fast: true
 
     steps:
 
@@ -85,15 +82,16 @@ jobs:
         export CC=mpicc
         set -x
         cd ncio
-        mkdir build && cd build
+        mkdir build
+        cd build
         cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
     
     - name: test
       run: |
+        cd $GITHUB_WORKSPACE/ncio/build
         pwd
         ls -l 
-        cd $GITHUB_WORKSPACE/ncio/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
 
@@ -101,5 +99,5 @@ jobs:
       with:
         name: test-coverage
         path: |
-          NCEPLIBS-ncio/build/*.html
-          NCEPLIBS-ncio/build/*.css
+          ncio/build/*.html
+          ncio/build/*.css

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -5,7 +5,13 @@
 #
 # Ed Hartnett 1/12/23
 name: developer
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
 
 jobs:
   developer:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -87,7 +87,9 @@ jobs:
     
     - name: test
       run: |
-        cd $GITHUB_WORKSPACE/NCEPLIBS-ncio/build
+        pwd
+        ls -l *
+        cd $GITHUB_WORKSPACE/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -91,7 +91,8 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/ncio/build
         pwd
-        ls -l 
+        ls -l
+        gcovr --version
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -88,7 +88,7 @@ jobs:
     - name: test
       run: |
         pwd
-        ls -l *
+        ls -l 
         cd $GITHUB_WORKSPACE/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -77,16 +77,20 @@ jobs:
         make -j2
         make install   
        
-    - name: build and test
+    - name: build
       run: |
         export FC=mpifort
         export CC=mpicc
         mkdir build && cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0" ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall -fno-omit-frame-pointer -fsanitize=address" ..
         make -j2 VERBOSE=1
-        ctest --output-on-failure
-        gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
     
+    - name: test
+      run: |
+        cd $GITHUB_WORKSPACE/NCEPLIBS-ncio/build
+        ctest --verbose --output-on-failure --rerun-failed
+        gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html &> /dev/null
+
     - uses: actions/upload-artifact@v2
       with:
         name: test-coverage

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -17,8 +17,8 @@ jobs:
   developer:
     runs-on: ubuntu-latest
     env:
-      FC: gfortran-9
-      CC: gcc-9
+      FC: gfortran
+      CC: gcc
 
     steps:
 
@@ -27,8 +27,7 @@ jobs:
     - name: install-dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libmpich-dev
-        sudo apt-get install doxygen
+        sudo apt-get install libmpich-dev doxygen
         python3 -m pip install gcovr
 
     - name: cache-netcdf

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -22,8 +22,7 @@ jobs:
     - name: install-dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libmpich-dev doxygen
-        python3 -m pip install gcovr
+        sudo apt-get install libmpich-dev doxygen gcovr
 
     - name: cache-netcdf
       id: cache-netcdf
@@ -84,7 +83,7 @@ jobs:
         cd ncio
         mkdir build
         cd build
-        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" ..
+        cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=Yes -DCMAKE_PREFIX_PATH='~;~/netcdf' -DCMAKE_Fortran_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -Wall" ..
         make -j2 VERBOSE=1
     
     - name: test

--- a/README.md
+++ b/README.md
@@ -14,11 +14,18 @@ https://noaa-emc.github.io/NCEPLIBS-ncio/.
 NCEPLIBS-ncio is part of the
 [NCEPLIBS](https://github.com/NOAA-EMC/NCEPLIBS) project.
 
+To submit bug reports, feature requests, or other code-related issues
+including installation and usage questions, please create a [GitHub
+issue](https://github.com/NOAA-EMC/NCEPLIBS-ncio/issues). For general
+NCEPLIBS inquiries, contact [Edward
+Hartnett](mailto:edward.hartnett@noaa.gov) (secondary point of contact
+[Alex Richert](mailto:alexander.richert@noaa.gov)).
+
 ## Authors
 
 Jeff Whitaker, Cory Martin
 
-Code manager: Edward Hartnett, Hang Lei
+Code manager: [Edward Hartnett](mailto:edward.hartnett@noaa.gov), [Hang Lei](mailto:hang.lei@noaa.gov)
 
 ## Prerequisites
 
@@ -29,9 +36,21 @@ This package requires:
 
 ## Installing
 
-module for reading/writing netcdf gridded data.
-API docs [here](https://github.com/NOAA-EMC/NCEPLIBS-ncio/blob/develop/docs/user_guide.md).
-Example usage:
+```
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/path/to/install ..
+make -j2
+make install
+```
+
+## Using
+
+This library contains a module for reading/writing netcdf gridded
+data.  API docs
+[here](https://github.com/NOAA-EMC/NCEPLIBS-ncio/blob/develop/docs/user_guide.md).
+
+### Examples
 
 * open a Dataset.
 ```fortran


### PR DESCRIPTION
Fixed #77 

Also updated README.

I tried a lot of things to get the gcovr working, but the thing that finally did it was to change:

`        python3 -m pip install gcovr
`
to just:

`        sudo apt-get install libmpich-dev doxygen gcovr
`
In other words get gcovr with apt-get instead of pip.

Pip gives us version 6.0 whereas apt-get gives us 4.2.

The commands we have work fine with 4.2 but seem to not work with 6.0. Not sure why.

@AlexanderRichert-NOAA please take note because I think this gcovr problem occurs in other repos as well...