### PR TITLE
Add IntelLLVM support & add Spack-based CI

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -21,9 +21,9 @@ defaults:
 jobs:
   Intel:
     runs-on: ubuntu-latest
-    env:
-      CC: mpicc
-      FC: mpifort
+    strategy:
+      matrix:
+        compilers: ["oneapi", "classic"]
 
     steps:
 
@@ -32,32 +32,34 @@ jobs:
       # See https://software.intel.com/content/www/us/en/develop/articles/oneapi-repo-instructions.html
     - name: install-dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install libmpich-dev
         cd /tmp
         wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update
-        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-openmp intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran
         echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+        if [ ${{ matrix.compilers }} == "oneapi" ]; then
+          echo "export CC=mpiicx FC=mpiifx" >> ~/.bash_profile
+        elif [ ${{ matrix.compilers }} == "intel" ]; then
+          echo "export CC=mpiicc FC=mpiifort" >> ~/.bash_profile
+        fi
 
     - name: cache-netcdf
       id: cache-netcdf
       uses: actions/cache@v2
       with:
         path: ~/netcdf
-        key: Linux-netcdf-c-4.7.4-${{ runner.os }}1
+        key: Linux-netcdf-c-4.9.2-${{ runner.os }}-${{ matrix.compilers }}
 
     - name: build-hdf5
       if: steps.cache-netcdf.outputs.cache-hit != 'true'
       run: |
-        export CC=mpicc
-        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/hdf5-1.10.7/src/hdf5-1.10.7.tar.gz &> /dev/null
-        tar -xzf hdf5-1.10.7.tar.gz
-        pushd hdf5-1.10.7
-        ./configure --prefix=${HOME}/netcdf --enable-parallel --disable-tools --disable-fortran --disable-cxx --enable-parallel-tests
+        wget https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.14/hdf5-1.14.3/src/hdf5-1.14.3.tar.gz &> /dev/null
+        tar -xzf hdf5-1.14.3.tar.gz
+        pushd hdf5-1.14.3
+        ./configure --prefix=${HOME}/netcdf --enable-parallel --disable-tools --disable-fortran --disable-cxx --disable-parallel-tests --disable-tests --disable-static
         make -j2 VERBOSE=1
         make install
            
@@ -66,22 +68,27 @@ jobs:
       run: |
         export CPPFLAGS=-I${HOME}/netcdf/include
         export LDFLAGS=-L${HOME}/netcdf/lib
-        wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.7.4.tar.gz
-        tar -xzf v4.7.4.tar.gz
-        cd netcdf-c-4.7.4
-        ./configure --prefix=${HOME}/netcdf --disable-dap --disable-utilities
+        wget https://github.com/Unidata/netcdf-c/archive/refs/tags/v4.9.2.tar.gz
+        tar -xzf v4.9.2.tar.gz
+        cd netcdf-c-4.9.2
+        ./configure --prefix=${HOME}/netcdf --disable-dap --disable-byterange --disable-utilities
         make -j2 VERBOSE=1
         make install
 
     - name: build-netcdf-fortran
       if: steps.cache-netcdf.outputs.cache-hit != 'true'
       run: |
+        # Avoid mpiifx wrapper bug in netcdf-fortran installation
+        if [ ${{ matrix.compilers}} == oneapi ]; then
+          export CC=icx FC=ifx
+        fi
         export PATH="${HOME}/netcdf/bin:$PATH"
         export CPPFLAGS=-I${HOME}/netcdf/include
         export LDFLAGS=-L${HOME}/netcdf/lib
-        wget https://github.com/Unidata/netcdf-fortran/archive/v4.5.3.tar.gz &> /dev/null
-        tar -xzf v4.5.3.tar.gz
-        pushd netcdf-fortran-4.5.3
+        export LD_LIBRARY_PATH=${HOME}/netcdf/lib:$LD_LIBRARY_PATH
+        wget https://github.com/Unidata/netcdf-fortran/archive/v4.6.1.tar.gz &> /dev/null
+        tar -xzf v4.6.1.tar.gz
+        pushd netcdf-fortran-4.6.1
         ./configure --prefix=${HOME}/netcdf
         make -j2 VERBOSE=1
         make install   
@@ -92,6 +99,3 @@ jobs:
         cmake -DCMAKE_PREFIX_PATH='~;~/netcdf' ..
         make -j2 VERBOSE=1
         ctest --verbose --output-on-failure --rerun-failed
-
-
-      

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -1,0 +1,90 @@
+# This is a CI workflow for the NCEPLIBS-ncio project.
+#
+# This workflow builds ncio with Spack, including installing with the "--test
+# root" option to run the Ctest suite. It also has a one-off job that validates
+# the recipe by ensuring that every CMake option that should be set in the
+# Spack recipe is so set.
+#
+# Alex Richert, Sep 2023
+name: Spack
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  Spack:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    
+    - name: checkout-ncio
+      uses: actions/checkout@v4
+      with: 
+        path: ncio
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v3
+      with:
+        path: ~/spack-build-cache
+        key: spack-build-cache-${{ matrix.os }}-1
+
+    - name: spack-build-and-test
+      run: |
+        sudo apt install openmpi-bin libopenmpi-dev
+        cd
+        git clone -c feature.manyFiles=true https://github.com/jcsda/spack
+        . spack/share/spack/setup-env.sh
+        spack env create ncio-env
+        spack env activate ncio-env
+        cp $GITHUB_WORKSPACE/ncio/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/ncio/package.py
+        spack develop --no-clone --path $GITHUB_WORKSPACE/ncio ncio@develop
+        spack add ncio@develop%gcc@11 ^netcdf-c ~blosc ~szip ^openmpi
+        spack external find cmake gmake openmpi
+        spack config add "packages:openmpi:buildable:false"
+        for mirror in $(spack mirror list | awk '{print $1}'); do
+          spack mirror rm --scope defaults ${mirror}
+        done
+        spack mirror add spack-build-cache ~/spack-build-cache
+        spack concretize
+        # Run installation and run CTest suite
+        if [  "${{ steps.cache.outputs.cache-hit }}" == true ]; then deps=only; else deps=auto; fi
+        spack install --verbose --fail-fast --no-check-signature --use-buildcache package:never,dependencies:${deps} --test root
+        # Run 'spack load' to check for obvious errors in setup_run_environment
+        spack load ncio
+        ls $NCIO_LIB
+        spack buildcache push --only dependencies --unsigned --allow-root ~/spack-build-cache ncio
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
+        path: ${{ github.workspace }}/ncio/spack-build-*/Testing/Temporary/LastTest.log
+
+  # This job validates the Spack recipe by making sure each cmake build option is represented
+  recipe-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    
+    - name: checkout-ncio
+      uses: actions/checkout@v4
+      with: 
+        path: ncio
+
+    - name: recipe-check
+      run: |
+        echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
+        for opt in $(grep -ioP '^option\(\K(?!(ENABLE_DOCS))[^ ]+' $GITHUB_WORKSPACE/ncio/CMakeLists.txt) ; do
+          echo "Checking for presence of '$opt' CMake option in package.py"
+          grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/ncio/spack/package.py
+        done

--- a/cmake/mpi_test.cmake
+++ b/cmake/mpi_test.cmake
@@ -25,6 +25,12 @@ function (add_mpi_test TESTNAME)
                   DOC "Executable for running MPI programs." )
   endif()
 
+# Check whether OpenMPI, in which case we need --oversubscribe in GitHub CI
+  execute_process(COMMAND ${MPIEXEC} --version OUTPUT_VARIABLE VERSIONOUTPUT)
+  if(VERSIONOUTPUT MATCHES ".*OpenRTE.*")
+    set(MPIEXEC_PREFLAGS "--oversubscribe" ${MPIEXEC_PREFLAGS})
+  endif()
+
   # Run tests directly from the command line
   set(EXE_CMD ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${num_procs}
       ${MPIEXEC_PREFLAGS}  ${exec_file}

--- a/spack/README
+++ b/spack/README
@@ -1,0 +1,3 @@
+This directory contains an authoritative, up-to-date Spack recipe for NCEPLIBS-ncio, which is found under Spack as "ncio".
+
+Before each release of NCEPLIBS-ncio, this file should be updated to accommodate changes in build options, etc., and .github/workflows/spack.yml should be updated to exercise all variants. Only the version entry should need to be updated after the release prior to incorporation into the Spack repository and the JCSDA Spack fork.

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,0 +1,38 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Ncio(CMakePackage):
+    """This is a library used by NCEP GSI system to read the GFS forecast
+    files for use in data assimilation.
+
+    This is part of NOAA's NCEPLIBS project."""
+
+    homepage = "https://github.com/NOAA-EMC/NCEPLIBS-ncio"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-ncio/archive/refs/tags/v1.0.0.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-ncio"
+
+    maintainers("edwardhartnett", "AlexanderRichert-NOAA", "Hang-Lei-NOAA")
+
+    version("develop", branch="develop")
+    version("1.1.2", sha256="2e4506fe3176344f28e837f2f69bcbd3dda51a64cacf33af0e435b13abe094fc")
+    version("1.1.1", sha256="c1cfeb3d731a2ae858bdfc02b2914fd6c8eac5cc76c7e67eb2580ae5e7500a2b")
+    version("1.1.0", sha256="9de05cf3b8b1291010197737666cede3d621605806379b528d2146c4f02d08f6")
+    version("1.0.0", sha256="2e2630b26513bf7b0665619c6c3475fe171a9d8b930e9242f5546ddf54749bd4")
+
+    depends_on("mpi")
+    depends_on("netcdf-fortran")
+
+    def setup_run_environment(self, env):
+        lib = find_libraries("libncio", root=self.prefix, shared=False, recursive=True)
+        env.set("NCIO_LIB", lib[0])
+        env.set("NCIO_INC", join_path(self.prefix, "include"))
+        env.set("NCIO_LIBDIR", lib[0])
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ elseif(UNIX)
   add_compile_definitions(LINUX)
 endif()
 
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS "-g -traceback -convert big_endian -assume byterecl ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O2")
   set(CMAKE_Fortran_FLAGS_DEBUG "-ftrapuv")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,5 +18,6 @@ target_link_libraries(tst_ncio_mpi PRIVATE ncio::ncio)
 add_mpi_test(tst_ncio_mpi
   EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/tst_ncio_mpi
   NUMPROCS 4
-  TIMEOUT 60)
+  TIMEOUT 60
+)
 


### PR DESCRIPTION
This PR adds IntelLLVM (OneAPI) support (including CI tests for both Intel compilers), as well as a Spack-based CI workflow (which uses OpenMPI). It also uses Intel MPI+ifort in the Intel (Classic) CI, rather than MPICH+gfortran (#82).

Fixes #82 
Fixes #83 
Fixes #84